### PR TITLE
chore: onboard APIScan

### DIFF
--- a/.azure-pipelines/apiscan.yml
+++ b/.azure-pipelines/apiscan.yml
@@ -1,0 +1,82 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      sourceAnalysisPool: 1es-windows-2022-x64
+      tsa:
+        enabled: true
+
+    stages:
+      - stage: Build
+        jobs:
+        - job: APIScan
+          pool:
+            name: 1es-windows-2022-x64
+            os: Windows
+          steps:
+            - pwsh: |
+                echo @"<?xml version="1.0" encoding="utf-8"?>
+                  <configuration>
+                    <packageSources>
+                      <clear />
+                      <add key="node-speech" value="https://pkgs.dev.azure.com/monacotools/Monaco/_packaging/node-speech/nuget/v3/index.json" />
+                    </packageSources>
+                  </configuration>
+                "@ > nuget.config
+              displayName: Change feed
+
+            - task: NuGetAuthenticate@1
+
+            - pwsh: ./setup-packages.ps1
+              displayName: Download and extract C# packages
+
+            - script: npm ci
+              displayName: Install and build
+
+            - task: CopyFiles@2
+              inputs:
+                SourceFolder: '$(Build.SourcesDirectory)/build'
+                Contents: |
+                  '**\*.dll'
+                  '**\*.node'
+                  '**\*.pdb'
+                TargetFolder: '$(Agent.TempDirectory)/apiscan'
+                flattenFolders: true
+              displayName: Copy files for APIScan
+              condition: succeeded()
+
+            # Run APIScan
+            # - task: APIScan@2
+            #   inputs:
+            #     softwareFolder: '$(Agent.TempDirectory)/apiscan'
+            #     softwareName: 'vscode-node-speech'
+            #     softwareVersionNum: '1'
+            #     isLargeApp: false
+            #     toolVersion: 'Latest'
+            #   displayName: Run APIScan
+            #   condition: succeeded()
+            #   env:
+            #     AzureServicesAuthConnectionString: $(apiscan-connectionstring)
+
+            - task: PublishSecurityAnalysisLogs@3
+              displayName: Publish security logs
+              inputs:
+                ArtifactName: 'CodeAnalysisLogs'
+                ArtifactType: 'Container'
+                AllTools: true
+                ToolLogsNotFoundAction: 'Standard'

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -29,6 +29,9 @@ extends:
       - name: node-speech
 
         buildSteps:
+          - pwsh: ./setup-packages.ps1
+            displayName: Download and extract C# packages
+
           - script: npm ci
             displayName: Install and build
 
@@ -44,13 +47,16 @@ extends:
               - 18.x
 
         testSteps:
+          - pwsh: ./setup-packages.ps1
+            displayName: Download and extract C# packages
+
           - script: npm ci
             displayName: Install and build
 
           - script: npm run test
             displayName: Test npm package
 
-        apiScanSoftwareName: 'vscode-node-speech'
-        apiScanSoftwareVersion: '1'
+        # Run on the internal pipeline instead
+        skipApiScan: true
 
         publishPackage: ${{ parameters.publishPackage }}

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -29,9 +29,6 @@ extends:
       - name: node-speech
 
         buildSteps:
-          - pwsh: ./setup-packages.ps1
-            displayName: Download and extract C# packages
-
           - script: npm ci
             displayName: Install and build
 
@@ -47,9 +44,6 @@ extends:
               - 18.x
 
         testSteps:
-          - pwsh: ./setup-packages.ps1
-            displayName: Download and extract C# packages
-
           - script: npm ci
             displayName: Install and build
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ build
 !preinstall.js
 *.js.map
 *.d.ts
+
+temp_packages
+bin
+obj
+*.csproj.*
+project.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to node-speech
+
+## Building the project
+
+### Prerequisites
+
+- [.NET SDK](https://dotnet.microsoft.com/en-us/download) (The default recommended LTS version should work)
+- [pwsh](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.4)
+- Node.js and npm
+
+### Steps
+
+1. Clone the repository: `git clone https://github.com/microsoft/node-speech.git`
+2. Run the powershell script, `setup-packages.ps1`. This script uses dotnet to add various Speech SDK packages required for this repository, and copies the nupkg files to `.cache/packages`.
+3. Run the install script: `npm i`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,4 @@
 ### Steps
 
 1. Clone the repository: `git clone https://github.com/microsoft/node-speech.git`
-2. Run the powershell script, `setup-packages.ps1`. This script uses dotnet to add various Speech SDK packages required for this repository, and copies the nupkg files to `.cache/packages`.
-3. Run the install script: `npm i`.
+2. Run the install script: `npm i`.

--- a/node-speech.csproj
+++ b/node-speech.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>node_speech</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.37.0" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.Embedded.SR" Version="1.37.0" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.Embedded.TTS" Version="1.37.0" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.ONNX.Runtime" Version="1.37.0" />
+  </ItemGroup>
+
+</Project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/node-speech",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/node-speech",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "install": "node preinstall.js",
+    "install": "pwsh setup-packages.ps1 && node preinstall.js",
     "postinstall": "node-gyp rebuild",
     "prepublish": "tsc",
     "prepare": "npm run test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/node-speech",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Native bindings for Micrsooft Speech SDK",
   "repository": {
     "type": "git",

--- a/preinstall.js
+++ b/preinstall.js
@@ -8,18 +8,17 @@
 
 const fs = require('fs');
 const path = require('path');
-const stream = require('stream');
 const { finished } = require('stream/promises');
 const yauzl = require('yauzl');
 
 const SDK_VERSION = '1.37.0';
 
 const packages = {
-  'Microsoft.CognitiveServices.Speech': SDK_VERSION,
-  'Microsoft.CognitiveServices.Speech.Extension.Embedded.SR': SDK_VERSION,
-  'Microsoft.CognitiveServices.Speech.Extension.Embedded.TTS': SDK_VERSION,
-  'Microsoft.CognitiveServices.Speech.Extension.ONNX.Runtime': SDK_VERSION,
-  // 'Microsoft.CognitiveServices.Speech.Extension.Telemetry': SDK_VERSION,
+  'microsoft.cognitiveservices.speech': SDK_VERSION,
+  'microsoft.cognitiveservices.speech.extension.embedded.sr': SDK_VERSION,
+  'microsoft.cognitiveservices.speech.extension.embedded.tts': SDK_VERSION,
+  'microsoft.cognitiveservices.speech.extension.onnx.runtime': SDK_VERSION,
+  // 'microsoft.cognitiveservices.speech.extension.telemetry': SDK_VERSION,
 };
 
 async function decompress(packagePath, outputPath) {
@@ -61,31 +60,10 @@ async function decompress(packagePath, outputPath) {
 
 async function main(packages) {
   const cacheDir = path.join(__dirname, '.cache');
-  await fs.promises.mkdir(path.join(cacheDir, 'packages'), { recursive: true });
-  await fs.promises.mkdir(path.join(cacheDir, 'SpeechSDK'), { recursive: true });
+  const sdkPath = path.join(cacheDir, 'SpeechSDK');
 
   for (const [name, version] of Object.entries(packages)) {
-    const url = `https://www.nuget.org/api/v2/package/${name}/${version}`;
-    const packagePath = path.join(cacheDir, 'packages', `${name}-${version}.nupkg`);
-
-    if (fs.existsSync(packagePath)) {
-      console.log(`Found ${name} ${version} in cache, skipping.`);
-      continue;
-    }
-
-    const sdkPath = path.join(cacheDir, 'SpeechSDK');
-
-    const res = await fetch(url);
-
-    if (!res.ok) {
-      throw new Error(`Failed to download ${name} ${version}: ${res.statusText}`);
-    }
-
-    console.log(`Downloading ${name} ${version}...`);
-    const istream = stream.Readable.fromWeb(res.body);
-    const ostream = fs.createWriteStream(packagePath);
-    await finished(istream.pipe(ostream));
-
+    const packagePath = path.join(cacheDir, 'packages', `${name}.${version}.nupkg`);
     await decompress(packagePath, sdkPath);
   }
 }

--- a/setup-packages.ps1
+++ b/setup-packages.ps1
@@ -10,4 +10,4 @@ New-Item -Path .cache/packages -Type Directory
 New-Item -Path .cache/SpeechSDK -Type Directory
 Get-ChildItem -Path $TEMP_PACKAGE_DIR -Recurse -Filter "*.nupkg" | Foreach-Object { cp $_ .cache/packages }
 
-rm -recurse $TEMP_PACKAGE_DIR
+rm -recurse -Force $TEMP_PACKAGE_DIR

--- a/setup-packages.ps1
+++ b/setup-packages.ps1
@@ -1,0 +1,13 @@
+$SDK_VERSION = "1.37.0"
+$TEMP_PACKAGE_DIR = "temp_packages"
+
+dotnet add package Microsoft.CognitiveServices.Speech --version $SDK_VERSION --package-directory $TEMP_PACKAGE_DIR
+dotnet add package Microsoft.CognitiveServices.Speech.Extension.Embedded.SR --version $SDK_VERSION --package-directory $TEMP_PACKAGE_DIR
+dotnet add package Microsoft.CognitiveServices.Speech.Extension.Embedded.TTS --version $SDK_VERSION --package-directory $TEMP_PACKAGE_DIR
+dotnet add package Microsoft.CognitiveServices.Speech.Extension.ONNX.Runtime --version $SDK_VERSION --package-directory $TEMP_PACKAGE_DIR
+
+New-Item -Path .cache/packages -Type Directory
+New-Item -Path .cache/SpeechSDK -Type Directory
+Get-ChildItem -Path $TEMP_PACKAGE_DIR -Recurse -Filter "*.nupkg" | Foreach-Object { cp $_ .cache/packages }
+
+rm -recurse $TEMP_PACKAGE_DIR

--- a/setup-packages.ps1
+++ b/setup-packages.ps1
@@ -10,4 +10,4 @@ New-Item -Path .cache/packages -Type Directory
 New-Item -Path .cache/SpeechSDK -Type Directory
 Get-ChildItem -Path $TEMP_PACKAGE_DIR -Recurse -Filter "*.nupkg" | Foreach-Object { cp $_ .cache/packages }
 
-rm -recurse -Force $TEMP_PACKAGE_DIR
+Remove-Item -Path $TEMP_PACKAGE_DIR -Force -Recurse


### PR DESCRIPTION
This PR modifies the C# packages setup script to allow for a new and separate APIScan pipeline that runs on the internal packages as part of an internal compliance ask. However, with this change, contributors would have to install pwsh and dotnet SDK to set up their workspace.