### PR TITLE
chore: enable TSA for APIScan pipeline

### DIFF
--- a/.azure-pipelines/apiscan.yml
+++ b/.azure-pipelines/apiscan.yml
@@ -19,7 +19,7 @@ extends:
     sdl:
       sourceAnalysisPool: 1es-windows-2022-x64
       tsa:
-        enabled: false # TSA is already covered by pipeline.yml
+        enabled: true
 
     stages:
       - stage: Build


### PR DESCRIPTION
Enables TSA so that results show up under the internal query board for increased transparency and visibility within the team.