### PR TITLE
chore: do not flatten folders for APIScan

### DIFF
--- a/.azure-pipelines/apiscan.yml
+++ b/.azure-pipelines/apiscan.yml
@@ -81,7 +81,6 @@ extends:
                     build/**/*.pdb
                     .cache/SpeechSDK/**/*.pdb
                   TargetFolder: "$(Agent.TempDirectory)/apiscan"
-                  flattenFolders: true
                 displayName: Copy files for APIScan
                 condition: succeeded()
 


### PR DESCRIPTION
The CopyFiles task is currently flattening folders while copying files over, resulting in APIScan mixing the files up due to potential name collisions.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=291804&view=results