### PR TITLE
chore: use inline TSAUpload task

### DIFF
--- a/.azure-pipelines/apiscan.yml
+++ b/.azure-pipelines/apiscan.yml
@@ -110,9 +110,9 @@ extends:
                   AllTools: true
                   ToolLogsNotFoundAction: "Standard"
 
-              # - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
-              #   displayName: 🔒 TSA Upload
-              #   continueOnError: true
-              #   inputs:
-              #     GdnPublishTsaConfigFile: $(Build.SourcesDirectory)/.config/tsaoptions.json
-              #     GdnPublishTsaOnboard: True
+              - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
+                displayName: 🔒 TSA Upload
+                continueOnError: true
+                inputs:
+                  GdnPublishTsaConfigFile: $(Build.SourcesDirectory)/.config/tsaoptions.json
+                  GdnPublishTsaOnboard: True

--- a/.azure-pipelines/apiscan.yml
+++ b/.azure-pipelines/apiscan.yml
@@ -31,9 +31,6 @@ extends:
             variables:
               - group: "API Scan"
             steps:
-              - pwsh: echo $(Build.Repository.Name)
-                displayName: Log repository name
-
               - pwsh: |
                   echo @"
                   <?xml version="1.0" encoding="utf-8"?>

--- a/.azure-pipelines/apiscan.yml
+++ b/.azure-pipelines/apiscan.yml
@@ -19,14 +19,7 @@ extends:
     sdl:
       sourceAnalysisPool: 1es-windows-2022-x64
       tsa:
-        config:
-          areaPath: 'DevDiv\\VS Code (compliance tracking only)\\Visual Studio Code NPM Packages'
-          codebaseName: devdiv_${{ replace(variables['Build.Repository.Name'], '-', '_') }}
-          instanceUrl: "https://devdiv.visualstudio.com/defaultcollection"
-          notificationAliases: ["monacotools@microsoft.com"]
-          serviceTreeID: "f85a34fa-964a-4306-885a-003737c8fe18"
-          projectName: "DevDiv"
-        enabled: true
+        enabled: false # sdlSources TSA is already covered in pipeline.yml
 
     stages:
       - stage: Build
@@ -38,6 +31,9 @@ extends:
             variables:
               - group: "API Scan"
             steps:
+              - pwsh: echo $(Build.Repository.Name)
+                displayName: Log repository name
+
               - pwsh: |
                   echo @"
                   <?xml version="1.0" encoding="utf-8"?>
@@ -113,3 +109,10 @@ extends:
                   ArtifactType: "Container"
                   AllTools: true
                   ToolLogsNotFoundAction: "Standard"
+
+              # - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
+              #   displayName: 🔒 TSA Upload
+              #   continueOnError: true
+              #   inputs:
+              #     GdnPublishTsaConfigFile: $(Build.SourcesDirectory)/.config/tsaoptions.json
+              #     GdnPublishTsaOnboard: True

--- a/.azure-pipelines/apiscan.yml
+++ b/.azure-pipelines/apiscan.yml
@@ -19,6 +19,13 @@ extends:
     sdl:
       sourceAnalysisPool: 1es-windows-2022-x64
       tsa:
+        config:
+          areaPath: 'DevDiv\\VS Code (compliance tracking only)\\Visual Studio Code NPM Packages'
+          codebaseName: devdiv_${{ replace(variables['Build.Repository.Name'], '-', '_') }}
+          instanceUrl: "https://devdiv.visualstudio.com/defaultcollection"
+          notificationAliases: ["monacotools@microsoft.com"]
+          serviceTreeID: "f85a34fa-964a-4306-885a-003737c8fe18"
+          projectName: "DevDiv"
         enabled: true
 
     stages:

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,5 +1,5 @@
 {
-    "codebaseName": "devdiv_microsoft_vscode_node_speech",
+    "codebaseName": "devdiv_microsoft_node_speech",
     "instanceUrl": "https://devdiv.visualstudio.com/defaultcollection",
     "projectName": "DevDiv",
     "areaPath": "DevDiv\\VS Code (compliance tracking only)\\Visual Studio Code NPM Packages",

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{
+    "codebaseName": "devdiv_microsoft_vscode_node_speech",
+    "instanceUrl": "https://devdiv.visualstudio.com/defaultcollection",
+    "projectName": "DevDiv",
+    "areaPath": "DevDiv\\VS Code (compliance tracking only)\\Visual Studio Code NPM Packages",
+    "notificationAliases": [
+        "raymondzhao@microsoft.com"
+    ],
+    "serviceTreeID": "f85a34fa-964a-4306-885a-003737c8fe18"
+}


### PR DESCRIPTION
Uses the inline TSAUpload task to avoid duplicate non-APIScan SDL issues being filed to the internal query board.