### PR TITLE
chore: bump Speech SDK packages to 1.41.1

### DIFF
--- a/.azure-pipelines/apiscan.yml
+++ b/.azure-pipelines/apiscan.yml
@@ -28,8 +28,6 @@ extends:
             pool:
               name: 1es-windows-2022-x64
               os: Windows
-            variables:
-              - group: "API Scan"
             steps:
               - pwsh: |
                   echo @"
@@ -96,7 +94,7 @@ extends:
                 displayName: Run APIScan
                 condition: succeeded()
                 env:
-                  AzureServicesAuthConnectionString: $(apiscan-connectionstring)
+                  AzureServicesAuthConnectionString: RunAs=App;AppId=c0940da5-8bd3-4dd3-8af1-40774b50edbd;TenantId=72f988bf-86f1-41af-91ab-2d7cd011db47;ServiceConnectionId=3e55d992-b60d-414d-9071-e4fad359c748;
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
               - task: PublishSecurityAnalysisLogs@3

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -35,13 +35,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 18.x
+              - 20.x
           - name: MacOS
             nodeVersions:
-              - 18.x
+              - 20.x
           - name: Windows
             nodeVersions:
-              - 18.x
+              - 20.x
 
         testSteps:
           - script: npm ci

--- a/node-speech.csproj
+++ b/node-speech.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.40.0" />
-    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.Embedded.SR" Version="1.40.0" />
-    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.Embedded.TTS" Version="1.40.0" />
-    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.ONNX.Runtime" Version="1.40.0" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.41.1" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.Embedded.SR" Version="1.41.1" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.Embedded.TTS" Version="1.41.1" />
+    <PackageReference Include="Microsoft.CognitiveServices.Speech.Extension.ONNX.Runtime" Version="1.41.1" />
   </ItemGroup>
 
 </Project>

--- a/preinstall.js
+++ b/preinstall.js
@@ -11,7 +11,7 @@ const path = require('path');
 const { finished } = require('stream/promises');
 const yauzl = require('yauzl');
 
-const SDK_VERSION = '1.40.0';
+const SDK_VERSION = '1.41.1';
 
 const packages = {
   'microsoft.cognitiveservices.speech': SDK_VERSION,

--- a/setup-packages.ps1
+++ b/setup-packages.ps1
@@ -1,4 +1,4 @@
-$SDK_VERSION = "1.40.0"
+$SDK_VERSION = "1.41.1"
 $TEMP_PACKAGE_DIR = "temp_packages"
 
 mkdir $TEMP_PACKAGE_DIR


### PR DESCRIPTION
This PR fixes a long-standing APIScan issue and updates the build pipelines.

Verification builds:
- Product: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=304956&view=results
- APIScan: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=304957&view=results